### PR TITLE
Remove redundant helsemelding prefix

### DIFF
--- a/.nais/payload-signing-service-dev.yaml
+++ b/.nais/payload-signing-service-dev.yaml
@@ -1,7 +1,7 @@
 apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
-  name: "helsemelding-payload-signing-service"
+  name: "payload-signing-service"
   namespace: "helsemelding"
   labels:
     "team": "helsemelding"


### PR DESCRIPTION
Since we already deploy our apps to the `helsemelding` namespace in Kubernetes there is no need to prefix. 

See:

```
❯ k get pods -n helsemelding
NAME                                                    READY   STATUS    RESTARTS   AGE
edi-adapter-6bbbd466c9-rss2n                            2/2     Running   0          21h
helsemelding-payload-signing-service-7cc784b4f8-hbl6m   2/2     Running   0          18h
state-service-84698ff978-xpldm                          2/2     Running   0          55m
```