### PR TITLE
#46 Legge til logging av `trace_id `

### DIFF
--- a/src/main/kotlin/no/nav/helsemelding/payloadsigning/plugin/Routes.kt
+++ b/src/main/kotlin/no/nav/helsemelding/payloadsigning/plugin/Routes.kt
@@ -65,6 +65,7 @@ fun Route.externalRoutes(processingService: ProcessingService) {
 
 fun Route.postPayload(processingService: ProcessingService) = post("/payload") {
     val request = call.receive<PayloadRequest>()
+    log.debug { "PayloadRequest request received" }
 
     val result: Either<ProcessingError, PayloadResponse> = when (request.direction) {
         Direction.IN -> processingService.processIncoming(request)

--- a/src/main/kotlin/no/nav/helsemelding/payloadsigning/service/ProcessingService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/payloadsigning/service/ProcessingService.kt
@@ -32,15 +32,19 @@ class ProcessingService(
 
     fun processOutgoing(request: PayloadRequest): Either<ProcessingError, PayloadResponse> =
         either {
+            log.info { "Processing outgoing payload..." }
+
             val xmlDocument =
                 Either.catch { request.bytes.toXmlDocument() }
                     .mapLeft(ProcessingError::XmlParseFailed)
                     .bind()
+            log.info { "XML document is parsed" }
 
             val signedDocument =
                 signingService.signXml(xmlDocument)
                     .mapLeft(ProcessingError::SigningFailed)
                     .bind()
+            log.info { "XML document is signed" }
 
             PayloadResponse(signedDocument.toByteArray())
         }

--- a/src/main/kotlin/no/nav/helsemelding/payloadsigning/service/ProcessingService.kt
+++ b/src/main/kotlin/no/nav/helsemelding/payloadsigning/service/ProcessingService.kt
@@ -32,19 +32,19 @@ class ProcessingService(
 
     fun processOutgoing(request: PayloadRequest): Either<ProcessingError, PayloadResponse> =
         either {
-            log.info { "Processing outgoing payload..." }
+            log.debug { "Processing outgoing payload..." }
 
             val xmlDocument =
                 Either.catch { request.bytes.toXmlDocument() }
                     .mapLeft(ProcessingError::XmlParseFailed)
                     .bind()
-            log.info { "XML document is parsed" }
+            log.debug { "XML document is parsed" }
 
             val signedDocument =
                 signingService.signXml(xmlDocument)
                     .mapLeft(ProcessingError::SigningFailed)
                     .bind()
-            log.info { "XML document is signed" }
+            log.debug { "XML document is signed" }
 
             PayloadResponse(signedDocument.toByteArray())
         }


### PR DESCRIPTION
Det viste seg at `trace_id` blir logget automatisk når _autoinstrumentation_ er på og en _stan_ ble startet 🤖 
Så jeg har bare lagt til logging av steg i signeringsprosessen.

Oppgave: https://github.com/navikt/helsemelding-state-service/issues/46